### PR TITLE
Pre-queue amavisd config from mail-filter

### DIFF
--- a/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/00template_vars
+++ b/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/00template_vars
@@ -16,8 +16,7 @@
     @domainList = ( join('.', $SystemName, $DomainName),  $SystemName . '.localdomain',  'localhost');
 
     $hasDisclaimers = scalar grep {
-        ($_->prop('TransportType') || '') eq 'LocalDelivery'
-        && ($_->prop('DisclaimerStatus') || '') eq 'enabled'
+        ($_->prop('DisclaimerStatus') || '') eq 'enabled'
     } esmith::DomainsDB->open_ro()->get_all_by_prop('type' => 'domain');
 
     '';

--- a/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/60disclaimer
+++ b/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/60disclaimer
@@ -6,14 +6,11 @@ $defang_maps_by_ccat\{+CC_CATCHALL\} = [ 'disclaimer' ];
 @disclaimer_options_bysender_maps = ( {
     use esmith::DomainsDB;
 
-    $domainsDb = esmith::DomainsDB->open_ro() || die("Could not open DomainsDB");
-
     my $baseDir = '/var/lib/nethserver/mail-disclaimers/';
 
-    my @enabledDomains =  grep { 
-	my $disclaimerStatus = $domainsDb->get_prop($_, 'DisclaimerStatus'); 
-	defined $disclaimerStatus && $disclaimerStatus eq 'enabled' ? $_ : undef;  
-    } @domainList;
+    my @enabledDomains = map {
+        ($_->prop('DisclaimerStatus') || '') eq 'enabled' ? $_->key : ()
+    } esmith::DomainsDB->open_ro()->get_all_by_prop('type' => 'domain');
 
     my %disclaimerMap = ( 
         '.' => $baseDir . '_default_', # The default empty disclaimer. Fixes #1819

--- a/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/61domains_relay
+++ b/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/61domains_relay
@@ -1,0 +1,11 @@
+#
+# 61domains_relay -- Consider relay domains as "local inbound". Refs #3148
+# 
+push @local_domains_maps, {
+    use esmith::DomainsDB;
+    my $domainsDb = esmith::DomainsDB->open_ro();
+    my @relay_domains = map { $_->key } grep{ ($_->prop('TransportType') || '') eq 'Relay' } $domainsDb->domains();
+    $OUT = Dumper(\@relay_domains);
+};
+
+

--- a/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/71addresses_extension_relay
+++ b/root/etc/e-smith/templates/etc/amavisd/amavisd.conf/71addresses_extension_relay
@@ -1,0 +1,19 @@
+#
+# 71addresses_extension_relay -- disable address extensions
+#                                on relay domains.
+# {
+    use esmith::DomainsDB;
+    my $domainsDb = esmith::DomainsDB->open_ro();
+
+    %relay_map = (
+        map { $_->key => '' }
+            grep{ ($_->prop('TransportType') || '') eq 'Relay' }
+              $domainsDb->domains());
+    '';
+}
+unshift @addr_extension_virus_maps, { Dumper(\%relay_map); };
+unshift @addr_extension_banned_maps, { Dumper(\%relay_map); };
+unshift @addr_extension_spam_maps, { Dumper(\%relay_map); };
+unshift @addr_extension_bad_header_maps, { Dumper(\%relay_map); };
+
+

--- a/root/etc/e-smith/templates/etc/postfix/master.cf/00template_vars
+++ b/root/etc/e-smith/templates/etc/postfix/master.cf/00template_vars
@@ -7,6 +7,7 @@
     @smtpd_public_options = (
 	'smtpd_helo_required=yes',
 	'strict_rfc821_envelopes=yes',
+    'smtpd_proxy_filter=127.0.0.1:10024',
 	'smtpd_proxy_options=speed_adjust',
     );
 
@@ -30,9 +31,20 @@
     # Is the disclaimer feature actually used? Refs #3411
     use esmith::DomainsDB;
     $hasDisclaimers = scalar grep {
-        ($_->prop('TransportType') || '') eq 'LocalDelivery'
-        &&($_->prop('DisclaimerStatus') || '') eq 'enabled'
+        ($_->prop('DisclaimerStatus') || '') eq 'enabled'
     } esmith::DomainsDB->open_ro()->get_all_by_prop('type' => 'domain');
+
+    # submission listeners talk directly to the backend instance (queue) on port 10025
+    # if disclaimers are not defined (See #3411):
+    push @submission_smtpd_options, 'smtpd_proxy_filter=127.0.0.1:' . ($hasDisclaimers ? 10587 : 10025);
+
+    # Override default values from DB:
+    $connections_limit = int($postfix{ConnectionsLimit});
+    $connections_limit_per_ip = int($postfix{ConnectionsLimitPerIp});
+
+    if($connections_limit_per_ip > 0) {
+        push @smtpd_public_options, ('smtpd_client_connection_count_limit=' . $connections_limit_per_ip);
+    }
 
     '';
 }

--- a/root/etc/e-smith/templates/etc/postfix/master.cf/30postfix-queue
+++ b/root/etc/e-smith/templates/etc/postfix/master.cf/30postfix-queue
@@ -1,0 +1,20 @@
+#
+# 30postfix-queue --  Receive mail
+# from the amavis content filter on localhost port 10025.
+# Re-inject messages into postfix queue after amavsid filter.
+#
+{
+    $OUT = q(
+127.0.0.1:10025 inet n  -       n       -        -      smtpd
+    -o smtpd_authorized_xforward_hosts=127.0.0.0/8
+    -o smtpd_client_restrictions=
+    -o smtpd_helo_restrictions=
+    -o smtpd_sender_restrictions=
+    -o smtpd_recipient_restrictions=permit_mynetworks,reject
+    -o smtpd_data_restrictions=
+    -o mynetworks=127.0.0.0/8
+    -o receive_override_options=no_unknown_recipient_checks
+);
+
+}
+


### PR DESCRIPTION
Configuration imported and reworked from mail-filter. Disclaimers are
treated also for relayed domains to reflect actual UI.

Refs NethServer/dev#5080
See http://dev.nethserver.org/issues/3148
