### PR TITLE
Fix authentication against SMTP+GSSAPI servers

### DIFF
--- a/root/etc/e-smith/templates/etc/postfix/main.cf/40smarthost
+++ b/root/etc/e-smith/templates/etc/postfix/main.cf/40smarthost
@@ -16,6 +16,7 @@
 relayhost = [$postfix{SmartHostName}]:$postfix{SmartHostPort}
 smtp_sasl_auth_enable = ${auth_enable}
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_mechanism_filter = plain, login
 smtp_sasl_security_options =
 smtp_tls_policy_maps = hash:/etc/postfix/tls_policy
 FRAGMENT


### PR DESCRIPTION
Only plain password SMTP/AUTH mech is supported by smtp client

NethServer/dev#5366 - v6 backport